### PR TITLE
Feat/HashingLogic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,4 +34,4 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       # run tests!
-      - run: yarn test
+      - run: yarn test:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:8.9
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: yarn install --frozen-lockfile --prefer-offline
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --prefer-offline
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: yarn install --frozen-lockfile --prefer-offline
+      - run: yarn install --frozen-lockfile
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: yarn install --frozen-lockfile --prefer-offline
+      - run: yarn install
 
       - save_cache:
           paths:

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ import {
   getFormattedName,
   AttestationStatus,
 } from './src/AttestationTypes'
+import * as HashingLogic from './src/HashingLogic'
 
 export {
   AttestationType,
@@ -28,4 +29,5 @@ export {
   getBloomIDStrength,
   getFormattedName,
   AttestationStatus,
+  HashingLogic,
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  roots: ['<rootDir>/src'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+}

--- a/package.json
+++ b/package.json
@@ -15,9 +15,12 @@
     ]
   },
   "devDependencies": {
+    "@types/jest": "^23.3.2",
     "@types/node": "^10.9.4",
+    "jest": "^23.6.0",
     "lint-staged": "^7.2.0",
     "prettier": "^1.13.7",
+    "ts-jest": "^23.1.4",
     "tslint": "^5.11.0",
     "typescript": "^2.9.2"
   },
@@ -25,6 +28,7 @@
     "build": "./bin/build",
     "prepack": "yarn build",
     "prepare": "yarn build",
+    "test": "node_modules/.bin/jest",
     "watch": "./node_modules/.bin/tsc --watch"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     ]
   },
   "devDependencies": {
+    "@types/node": "^10.9.4",
     "lint-staged": "^7.2.0",
     "prettier": "^1.13.7",
     "tslint": "^5.11.0",
@@ -23,12 +24,14 @@
   "scripts": {
     "build": "./bin/build",
     "prepack": "yarn build",
-    "prepare": "yarn build"
+    "prepare": "yarn build",
+    "watch": "./node_modules/.bin/tsc --watch"
   },
   "dependencies": {
     "@types/lodash": "^4.14.116",
     "lodash": "^4.17.10",
     "ts-node": "^7.0.1",
-    "tsconfig-paths": "^3.5.0"
+    "tsconfig-paths": "^3.5.0",
+    "web3-utils": "^1.0.0-beta.36"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   },
   "dependencies": {
     "@types/lodash": "^4.14.116",
+    "js-sha3": "^0.8.0",
     "lodash": "^4.17.10",
+    "merkletreejs": "^0.0.10",
     "ts-node": "^7.0.1",
     "tsconfig-paths": "^3.5.0",
     "uuidv4": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "prepack": "yarn build",
     "prepare": "yarn build",
     "test": "node_modules/.bin/jest --watch",
+    "test:ci": "node_modules/.bin/jest",
     "watch": "./node_modules/.bin/tsc --watch"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attestations-lib",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lodash": "^4.17.10",
     "ts-node": "^7.0.1",
     "tsconfig-paths": "^3.5.0",
+    "uuidv4": "^1.0.1",
     "web3-utils": "^1.0.0-beta.36"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build": "./bin/build",
     "prepack": "yarn build",
     "prepare": "yarn build",
-    "test": "node_modules/.bin/jest",
+    "test": "node_modules/.bin/jest --watch",
     "watch": "./node_modules/.bin/tsc --watch"
   },
   "dependencies": {

--- a/src/AttestationTypes.ts
+++ b/src/AttestationTypes.ts
@@ -29,6 +29,9 @@ export enum AttestationTypeID {
   'utility' = 18,
   'income' = 19,
   'assets' = 20,
+  'full-name' = 21,
+  'birth-date' = 22,
+  'gender' = 23,
 }
 
 export type AttestationTypeManifest = {
@@ -140,6 +143,21 @@ export const AttestationTypes: AttestationTypeManifest = {
     id: AttestationTypeID.assets,
     scoreWeight: 15,
     nameFriendly: 'Assets Verification',
+  },
+  'full-name': {
+    id: AttestationTypeID['full-name'],
+    scoreWeight: 5,
+    nameFriendly: 'Full Name',
+  },
+  'birth-date': {
+    id: AttestationTypeID['birth-date'],
+    scoreWeight: 5,
+    nameFriendly: 'Date of Birth',
+  },
+  gender: {
+    id: AttestationTypeID['gender'],
+    scoreWeight: 5,
+    nameFriendly: 'Gender',
   },
 }
 

--- a/src/HashingLogic.test.ts
+++ b/src/HashingLogic.test.ts
@@ -5,16 +5,40 @@ const preComputedHashes = {
   emailAttestationType:
     '0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6',
   emailAttestation:
-    '0x5c836525f55b64ede01a232fafde74afa7a8a82b47ecfe599294317971b2f4b5',
+    '0x81b6819c368a22ea3b4b1b3ea939a6e8e264acaff4c314b8d2ed834536dcdfff',
+  phoneAttestationType:
+    '0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563',
+  phoneAttestation:
+    '0xa9f1b74f342ac217e990c3690728339f12af70ad93ad38b9d3284ad406ad24ad',
 }
 
-test('HashingLogic matches', () => {
+test('HashingLogic.hashAttestationTypes', () => {
   const emailAttestationType = AttestationTypeID.email
+  const phoneAttestationType = AttestationTypeID.phone
   const emailAttestationTypeHash = HashingLogic.hashAttestationTypes([
     emailAttestationType,
   ])
-  expect(emailAttestationTypeHash).toBe(preComputedHashes.emailAttestationType)
+  const phoneAttestationTypeHash = HashingLogic.hashAttestationTypes([
+    phoneAttestationType,
+  ])
+  const emailFirstCombinedAttestationTypeHash = HashingLogic.hashAttestationTypes(
+    [emailAttestationType, phoneAttestationType]
+  )
+  const phoneFirstCombinedAttestationTypeHash = HashingLogic.hashAttestationTypes(
+    [phoneAttestationType, emailAttestationType]
+  )
 
+  // Precomputed hashes should match (if they don't a bug has potentially been introduced)
+  expect(emailAttestationTypeHash).toBe(preComputedHashes.emailAttestationType)
+  expect(phoneAttestationTypeHash).toBe(preComputedHashes.phoneAttestationType)
+
+  // Differently sorted input arrays should output the same hash due to sorting prior to serialization / hashing
+  expect(emailFirstCombinedAttestationTypeHash).toBe(
+    phoneFirstCombinedAttestationTypeHash
+  )
+})
+
+test('HashingLogic hashAttestations matches', () => {
   const emailAttesation: HashingLogic.IAttestationData = {
     type: 'email',
     data: 'test@bloom.co',
@@ -22,10 +46,32 @@ test('HashingLogic matches', () => {
     version: '1.0.0',
   }
   const emailAttestationHash = HashingLogic.hashAttestations([emailAttesation])
+  const phoneAttestation: HashingLogic.IAttestationData = {
+    type: 'phone',
+    data: '+17203600587',
+    nonce: 'a3877038-79a9-477d-8037-9826032e6af0',
+    version: '1.0.0',
+  }
+  const phoneAttestationHash = HashingLogic.hashAttestations([phoneAttestation])
+
+  // Precomputed hashes should match (if they don't a bug has potentially been introduced)
   expect(emailAttestationHash).toBe(preComputedHashes.emailAttestation)
+  expect(phoneAttestationHash).toBe(preComputedHashes.phoneAttestation)
+
+  const emailFirstCombinedAttestationHash = HashingLogic.hashAttestations([
+    emailAttesation,
+    phoneAttestation,
+  ])
+  const phoneFirstCombinedAttestationHash = HashingLogic.hashAttestations([
+    phoneAttestation,
+    emailAttesation,
+  ])
+  expect(emailFirstCombinedAttestationHash).toBe(
+    phoneFirstCombinedAttestationHash
+  )
 })
 
-test('HashingLogic mismatches', () => {
+test('HashingLogic hashAttestations mismatches', () => {
   const emailAttestationType = AttestationTypeID.phone // Not email
   const emailAttestationTypeHash = HashingLogic.hashAttestationTypes([
     emailAttestationType,
@@ -42,4 +88,43 @@ test('HashingLogic mismatches', () => {
   }
   const emailAttestationHash = HashingLogic.hashAttestations([emailAttesation])
   expect(emailAttestationHash).not.toBe(preComputedHashes.emailAttestation)
+})
+
+test('HashingLogic orderedStringify', () => {
+  const objectA = {
+    name: 'Test Flower',
+    email: 'test@bloom.co',
+    phone: '+17203600587',
+  }
+  const objectB = {
+    email: 'test@bloom.co',
+    name: 'Test Flower',
+    phone: '+17203600587',
+  }
+  const objectC = {
+    email: 'test@bloom.co',
+    phone: '+17203600587',
+    name: 'Test Flower',
+  }
+  const objectD = {
+    email: 'test@bloom.com', // .com instead of .co
+    phone: '+17203600587',
+    name: 'Test Flower',
+  }
+
+  // serialized objects a, b, and c should be equal because of orderedStringify
+  expect(HashingLogic.orderedStringify(objectA)).toBe(
+    HashingLogic.orderedStringify(objectB)
+  )
+  expect(HashingLogic.orderedStringify(objectA)).toBe(
+    HashingLogic.orderedStringify(objectC)
+  )
+  expect(HashingLogic.orderedStringify(objectB)).toBe(
+    HashingLogic.orderedStringify(objectC)
+  )
+
+  // serialized objects will not equal because the data isn't the same
+  expect(HashingLogic.orderedStringify(objectA)).not.toBe(
+    HashingLogic.orderedStringify(objectD)
+  )
 })

--- a/src/HashingLogic.test.ts
+++ b/src/HashingLogic.test.ts
@@ -3,11 +3,11 @@ import {AttestationTypeID} from './AttestationTypes'
 
 const preComputedHashes = {
   emailAttestationType:
-    '5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2',
+    '0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6',
   emailAttestation:
     '4f40b2af901ae168de7c8514a932e71e91347cd0ba821162462d421f07e3cc42',
   phoneAttestationType:
-    'bc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a',
+    '0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563',
   phoneAttestation:
     '8495a0af5e35ade5b867bc6937f7d43d073b4ef25ffcc21c38d81d8ea529cfb8',
 }

--- a/src/HashingLogic.test.ts
+++ b/src/HashingLogic.test.ts
@@ -1,9 +1,5 @@
 import * as HashingLogic from './HashingLogic'
 import {AttestationTypeID} from './AttestationTypes'
-import MerkleTree from 'merkletreejs'
-
-// import MerkleTree from 'merkletreejs'
-// const MerkleTree = require('merkletreejs')
 
 const preComputedHashes = {
   emailAttestationType:
@@ -62,17 +58,17 @@ test('HashingLogic hashAttestations matches', () => {
   expect(emailAttestationHash).toBe(preComputedHashes.emailAttestation)
   expect(phoneAttestationHash).toBe(preComputedHashes.phoneAttestation)
 
-  // const emailFirstCombinedAttestationHash = HashingLogic.hashAttestations([
-  //   emailAttesation,
-  //   phoneAttestation,
-  // ])
-  // const phoneFirstCombinedAttestationHash = HashingLogic.hashAttestations([
-  //   phoneAttestation,
-  //   emailAttesation,
-  // ])
-  // expect(emailFirstCombinedAttestationHash).toBe(
-  //   phoneFirstCombinedAttestationHash
-  // )
+  const emailFirstMerkleTree = HashingLogic.getMerkleTree([
+    emailAttestation,
+    phoneAttestation,
+  ])
+  const phoneFirstMerkleTree = HashingLogic.getMerkleTree([
+    phoneAttestation,
+    emailAttestation,
+  ])
+  expect(emailFirstMerkleTree.getRoot().toString('hex')).toBe(
+    phoneFirstMerkleTree.getRoot().toString('hex')
+  )
 })
 
 test('HashingLogic hashAttestations mismatches', () => {
@@ -84,14 +80,14 @@ test('HashingLogic hashAttestations mismatches', () => {
     preComputedHashes.emailAttestationType
   )
 
-  const emailAttesation: HashingLogic.IAttestationData = {
+  const emailAttestation: HashingLogic.IAttestationData = {
     type: 'email',
     data: 'not-test@bloom.co', // Not test@bloom.co
     nonce: 'a3877038-79a9-477d-8037-9826032e6af0',
     version: '1.0.0',
   }
-  // const emailAttestationHash = HashingLogic.hashAttestations([emailAttesation])
-  // expect(emailAttestationHash).not.toBe(preComputedHashes.emailAttestation)
+  const emailAttestationHash = HashingLogic.hashAttestation(emailAttestation)
+  expect(emailAttestationHash).not.toBe(preComputedHashes.emailAttestation)
 })
 
 test('HashingLogic orderedStringify', () => {

--- a/src/HashingLogic.test.ts
+++ b/src/HashingLogic.test.ts
@@ -1,0 +1,45 @@
+import * as HashingLogic from './HashingLogic'
+import {AttestationTypeID} from './AttestationTypes'
+
+const preComputedHashes = {
+  emailAttestationType:
+    '0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6',
+  emailAttestation:
+    '0x5c836525f55b64ede01a232fafde74afa7a8a82b47ecfe599294317971b2f4b5',
+}
+
+test('HashingLogic matches', () => {
+  const emailAttestationType = AttestationTypeID.email
+  const emailAttestationTypeHash = HashingLogic.hashAttestationTypes([
+    emailAttestationType,
+  ])
+  expect(emailAttestationTypeHash).toBe(preComputedHashes.emailAttestationType)
+
+  const emailAttesation: HashingLogic.IAttestationData = {
+    type: 'email',
+    data: 'test@bloom.co',
+    nonce: 'a3877038-79a9-477d-8037-9826032e6af0',
+    version: '1.0.0',
+  }
+  const emailAttestationHash = HashingLogic.hashAttestations([emailAttesation])
+  expect(emailAttestationHash).toBe(preComputedHashes.emailAttestation)
+})
+
+test('HashingLogic mismatches', () => {
+  const emailAttestationType = AttestationTypeID.phone // Not email
+  const emailAttestationTypeHash = HashingLogic.hashAttestationTypes([
+    emailAttestationType,
+  ])
+  expect(emailAttestationTypeHash).not.toBe(
+    preComputedHashes.emailAttestationType
+  )
+
+  const emailAttesation: HashingLogic.IAttestationData = {
+    type: 'email',
+    data: 'not-test@bloom.co', // Not test@bloom.co
+    nonce: 'a3877038-79a9-477d-8037-9826032e6af0',
+    version: '1.0.0',
+  }
+  const emailAttestationHash = HashingLogic.hashAttestations([emailAttesation])
+  expect(emailAttestationHash).not.toBe(preComputedHashes.emailAttestation)
+})

--- a/src/HashingLogic.test.ts
+++ b/src/HashingLogic.test.ts
@@ -1,17 +1,19 @@
 import * as HashingLogic from './HashingLogic'
 import {AttestationTypeID} from './AttestationTypes'
+import MerkleTree from 'merkletreejs'
 
-const MerkleTree = require('merkletreejs')
+// import MerkleTree from 'merkletreejs'
+// const MerkleTree = require('merkletreejs')
 
 const preComputedHashes = {
   emailAttestationType:
     '5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2',
   emailAttestation:
-    '916384b118d284ce03f78e126c658c0a0be150e40590b81abc2626e48a68b341',
+    '4f40b2af901ae168de7c8514a932e71e91347cd0ba821162462d421f07e3cc42',
   phoneAttestationType:
     'bc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a',
   phoneAttestation:
-    '13b32cc88a37dfadbf17263189c226841deac32fcd576c3b4ce383f225df6459',
+    '8495a0af5e35ade5b867bc6937f7d43d073b4ef25ffcc21c38d81d8ea529cfb8',
 }
 
 test('HashingLogic.hashAttestationTypes', () => {
@@ -41,36 +43,36 @@ test('HashingLogic.hashAttestationTypes', () => {
 })
 
 test('HashingLogic hashAttestations matches', () => {
-  const emailAttesation: HashingLogic.IAttestationData = {
+  const emailAttestation: HashingLogic.IAttestationData = {
     type: 'email',
     data: 'test@bloom.co',
     nonce: 'a3877038-79a9-477d-8037-9826032e6af0',
     version: '1.0.0',
   }
-  const emailAttestationHash = HashingLogic.hashAttestations([emailAttesation])
+  const emailAttestationHash = HashingLogic.hashAttestation(emailAttestation)
   const phoneAttestation: HashingLogic.IAttestationData = {
     type: 'phone',
     data: '+17203600587',
     nonce: 'a3877038-79a9-477d-8037-9826032e6af0',
     version: '1.0.0',
   }
-  const phoneAttestationHash = HashingLogic.hashAttestations([phoneAttestation])
+  const phoneAttestationHash = HashingLogic.hashAttestation(phoneAttestation)
 
   // Precomputed hashes should match (if they don't a bug has potentially been introduced)
   expect(emailAttestationHash).toBe(preComputedHashes.emailAttestation)
   expect(phoneAttestationHash).toBe(preComputedHashes.phoneAttestation)
 
-  const emailFirstCombinedAttestationHash = HashingLogic.hashAttestations([
-    emailAttesation,
-    phoneAttestation,
-  ])
-  const phoneFirstCombinedAttestationHash = HashingLogic.hashAttestations([
-    phoneAttestation,
-    emailAttesation,
-  ])
-  expect(emailFirstCombinedAttestationHash).toBe(
-    phoneFirstCombinedAttestationHash
-  )
+  // const emailFirstCombinedAttestationHash = HashingLogic.hashAttestations([
+  //   emailAttesation,
+  //   phoneAttestation,
+  // ])
+  // const phoneFirstCombinedAttestationHash = HashingLogic.hashAttestations([
+  //   phoneAttestation,
+  //   emailAttesation,
+  // ])
+  // expect(emailFirstCombinedAttestationHash).toBe(
+  //   phoneFirstCombinedAttestationHash
+  // )
 })
 
 test('HashingLogic hashAttestations mismatches', () => {
@@ -88,8 +90,8 @@ test('HashingLogic hashAttestations mismatches', () => {
     nonce: 'a3877038-79a9-477d-8037-9826032e6af0',
     version: '1.0.0',
   }
-  const emailAttestationHash = HashingLogic.hashAttestations([emailAttesation])
-  expect(emailAttestationHash).not.toBe(preComputedHashes.emailAttestation)
+  // const emailAttestationHash = HashingLogic.hashAttestations([emailAttesation])
+  // expect(emailAttestationHash).not.toBe(preComputedHashes.emailAttestation)
 })
 
 test('HashingLogic orderedStringify', () => {
@@ -138,7 +140,7 @@ test('HashingLogic merkle trees / proofs', () => {
     nonce: 'a3877038-79a9-477d-8037-9826032e6af0',
     version: '1.0.0',
   }
-  const emailAttesation: HashingLogic.IAttestationData = {
+  const emailAttestation: HashingLogic.IAttestationData = {
     type: 'email',
     data: 'test@bloom.co',
     nonce: 'a3877038-79a9-477d-8037-9826032e6af1',
@@ -150,27 +152,31 @@ test('HashingLogic merkle trees / proofs', () => {
     nonce: 'a3877038-79a9-477d-8037-9826032e6af2',
     version: '1.0.0',
   }
-
-  const leaves = [
-    Buffer.from(HashingLogic.hashAttestation(fullNameAttestation), 'hex'),
-    Buffer.from(HashingLogic.hashAttestation(emailAttesation), 'hex'),
-    Buffer.from(HashingLogic.hashAttestation(phoneAttestation), 'hex'),
-  ]
-  const tree = new MerkleTree(leaves, (x: any) =>
-    Buffer.from(HashingLogic.hashAttestation(x), 'hex')
-  )
+  const tree = HashingLogic.getMerkleTree([
+    fullNameAttestation,
+    emailAttestation,
+    phoneAttestation,
+  ])
   const root = tree.getRoot()
-  const fullNameProof = tree.getProof(leaves[0])
-  expect(tree.verify(fullNameProof, leaves[0], root)).toBeTruthy()
-  expect(tree.verify(fullNameProof, leaves[1], root)).toBeFalsy()
+  const leaves = tree.getLeaves()
+  const emailProof = tree.getProof(
+    Buffer.from(HashingLogic.hashAttestation(emailAttestation), 'hex')
+  )
+  const fullNameProof = tree.getProof(
+    Buffer.from(HashingLogic.hashAttestation(fullNameAttestation), 'hex')
+  )
+  const phoneProof = tree.getProof(
+    Buffer.from(HashingLogic.hashAttestation(phoneAttestation), 'hex')
+  )
+
+  expect(tree.verify(emailProof, tree.getLeaves()[0], root)).toBeTruthy()
+  expect(tree.verify(emailProof, tree.getLeaves()[1], root)).toBeFalsy()
+  expect(tree.verify(emailProof, tree.getLeaves()[2], root)).toBeFalsy()
+
+  expect(tree.verify(fullNameProof, leaves[0], root)).toBeFalsy()
+  expect(tree.verify(fullNameProof, leaves[1], root)).toBeTruthy()
   expect(tree.verify(fullNameProof, leaves[2], root)).toBeFalsy()
 
-  const emailProof = tree.getProof(leaves[1])
-  expect(tree.verify(emailProof, leaves[0], root)).toBeFalsy()
-  expect(tree.verify(emailProof, leaves[1], root)).toBeTruthy()
-  expect(tree.verify(emailProof, leaves[2], root)).toBeFalsy()
-
-  const phoneProof = tree.getProof(leaves[2])
   expect(tree.verify(phoneProof, leaves[0], root)).toBeFalsy()
   expect(tree.verify(phoneProof, leaves[1], root)).toBeFalsy()
   expect(tree.verify(phoneProof, leaves[2], root)).toBeTruthy()

--- a/src/HashingLogic.ts
+++ b/src/HashingLogic.ts
@@ -2,7 +2,8 @@ import {AttestationTypeID} from './AttestationTypes'
 import {sortBy} from 'lodash'
 import {keccak256} from 'js-sha3'
 import MerkleTree from 'merkletreejs'
-// import MerkleTree from 'merkletreejs'
+
+const {soliditySha3} = require('web3-utils')
 const uuid = require('uuidv4')
 
 export const generateAttestationRequestNonceHash = () => keccak256(uuid())
@@ -73,7 +74,7 @@ export const getMerkleTree = (attestations: IAttestationData[]) => {
 }
 
 export const hashAttestationTypes = (types: AttestationTypeID[]) =>
-  keccak256(sortBy(types))
+  soliditySha3({type: 'uint256[]', value: sortBy(types)})
 
 export interface IAgreementParameters {
   /**

--- a/src/HashingLogic.ts
+++ b/src/HashingLogic.ts
@@ -1,4 +1,5 @@
 import {AttestationTypeID} from './AttestationTypes'
+import {sortBy} from 'lodash'
 
 const {soliditySha3} = require('web3-utils')
 const uuid = require('uuidv4')
@@ -38,11 +39,24 @@ export interface IAttestationData {
   version: string
 }
 
+/**
+ * Returns the value of `JSON.stringify` of a new object argument `obj`,
+ * which is a copy of `obj`, but its properties are sorted using
+ * `Array<string>.sort`.
+ */
+export const orderedStringify = (obj: {}) => {
+  let orderedObj = {}
+  Object.keys(obj)
+    .sort()
+    .map(o => (orderedObj[o] = obj[o]))
+  return JSON.stringify(orderedObj)
+}
+
 export const hashAttestations = (attestations: IAttestationData[]) => {
-  const individualAttestationHashes = attestations.map(a =>
+  const individualAttestationHashes = sortBy(attestations, ['type']).map(a =>
     soliditySha3({
       type: 'string',
-      value: JSON.stringify(a),
+      value: orderedStringify(a),
     })
   )
   const combinedAttestationHash = soliditySha3({
@@ -53,7 +67,7 @@ export const hashAttestations = (attestations: IAttestationData[]) => {
 }
 
 export const hashAttestationTypes = (types: AttestationTypeID[]) =>
-  soliditySha3({type: 'uint256[]', value: types})
+  soliditySha3({type: 'uint256[]', value: sortBy(types)})
 
 export interface IAgreementParameters {
   /**

--- a/src/HashingLogic.ts
+++ b/src/HashingLogic.ts
@@ -73,6 +73,10 @@ export const getMerkleTree = (attestations: IAttestationData[]) => {
   return new MerkleTree(leaves, x => Buffer.from(hashAttestation(x), 'hex'))
 }
 
+/**
+ * Given an array of type `AttestationTypeID`, sorts the array, and
+ * uses `soliditySha3` to hash the array.
+ */
 export const hashAttestationTypes = (types: AttestationTypeID[]) =>
   soliditySha3({type: 'uint256[]', value: sortBy(types)})
 

--- a/src/HashingLogic.ts
+++ b/src/HashingLogic.ts
@@ -1,11 +1,10 @@
 import {AttestationTypeID} from './AttestationTypes'
 import {sortBy} from 'lodash'
+import {keccak256} from 'js-sha3'
 
-const {soliditySha3} = require('web3-utils')
 const uuid = require('uuidv4')
 
-export const generateAttestationRequestNonceHash = () =>
-  soliditySha3({type: 'string', value: uuid()})
+export const generateAttestationRequestNonceHash = () => keccak256(uuid())
 
 export interface IAttestationData {
   /**
@@ -52,22 +51,23 @@ export const orderedStringify = (obj: {}) => {
   return JSON.stringify(orderedObj)
 }
 
+export const hashAttestation = (attestation: IAttestationData) => {
+  const attestationHash = keccak256(orderedStringify(attestation))
+  return attestationHash
+}
+
 export const hashAttestations = (attestations: IAttestationData[]) => {
-  const individualAttestationHashes = sortBy(attestations, ['type']).map(a =>
-    soliditySha3({
-      type: 'string',
-      value: orderedStringify(a),
-    })
+  const individualAttestationHashes = sortBy(attestations, ['type']).map(
+    hashAttestation
   )
-  const combinedAttestationHash = soliditySha3({
-    type: 'string',
-    value: JSON.stringify(individualAttestationHashes),
-  })
+  const combinedAttestationHash = keccak256(
+    JSON.stringify(individualAttestationHashes)
+  )
   return combinedAttestationHash
 }
 
 export const hashAttestationTypes = (types: AttestationTypeID[]) =>
-  soliditySha3({type: 'uint256[]', value: sortBy(types)})
+  keccak256(sortBy(types))
 
 export interface IAgreementParameters {
   /**

--- a/src/HashingLogic.ts
+++ b/src/HashingLogic.ts
@@ -143,7 +143,7 @@ export enum ChainId {
 }
 
 export const getAttestationAgreementEIP712 = (
-  params: IAgreementParameters,
+  message: IAgreementParameters,
   chainId: ChainId,
   verifyingContract: string
 ) => ({
@@ -156,8 +156,8 @@ export const getAttestationAgreementEIP712 = (
     ],
     AttestationRequest: [
       {name: 'subject', type: 'address'},
-      {name: 'attester', type: 'address'},
       {name: 'requester', type: 'address'},
+      {name: 'attester', type: 'address'},
       {name: 'dataHash', type: 'bytes32'},
       {name: 'typeHash', type: 'bytes32'},
       {name: 'nonce', type: 'bytes32'},
@@ -170,5 +170,5 @@ export const getAttestationAgreementEIP712 = (
     chainId,
     verifyingContract,
   },
-  message: params,
+  message,
 })

--- a/src/HashingLogic.ts
+++ b/src/HashingLogic.ts
@@ -2,11 +2,30 @@ import {AttestationTypeID} from './AttestationTypes'
 
 const {soliditySha3} = require('web3-utils')
 
-interface IAttestationData {
+export interface IAttestationData {
+  /**
+   * The type of attestation (phone, email, etc.)
+   */
   type: keyof typeof AttestationTypeID
+  /**
+   * Optionally identifies service used to perform attestation
+   */
   provider?: string
+  /**
+   * String representation of the attestations data.
+   *
+   * Email: test@bloom.co
+   * Any attestation that isn't a single string value will be
+   * a JSON string representing the attestation data.
+   */
   data: string
+  /**
+   * Attestation type nonce
+   */
   nonce: string
+  /**
+   * Semantic version used to keep track of attestation versions
+   */
   version: string
 }
 
@@ -27,7 +46,7 @@ export const hashAttestations = (attestations: IAttestationData[]) => {
 export const hashAttestationTypes = (types: AttestationTypeID[]) =>
   soliditySha3({type: 'uint256[]', value: types})
 
-interface IAgreementParameters {
+export interface IAgreementParameters {
   /**
    * ETH address of the subject
    */
@@ -54,7 +73,7 @@ interface IAgreementParameters {
   nonce: string
 }
 
-interface IAgreementEntry {
+export interface IAgreementEntry {
   type: string
   name: keyof IAgreementParameters
   value: string

--- a/src/HashingLogic.ts
+++ b/src/HashingLogic.ts
@@ -1,6 +1,10 @@
 import {AttestationTypeID} from './AttestationTypes'
 
 const {soliditySha3} = require('web3-utils')
+const uuid = require('uuidv4')
+
+export const generateAttestationRequestNonceHash = () =>
+  soliditySha3({type: 'string', value: uuid()})
 
 export interface IAttestationData {
   /**
@@ -11,13 +15,18 @@ export interface IAttestationData {
    * Optionally identifies service used to perform attestation
    */
   provider?: string
+  // tslint:disable:max-line-length
   /**
    * String representation of the attestations data.
    *
-   * Email: test@bloom.co
+   * ### Examples ###
+   * email: "test@bloom.co"
+   * sanction-screen: {\"firstName\":\"FIRSTNAME\",\"middleName\":\"MIDDLENAME\",\"lastName\":\"LASTNAME\",\"birthMonth\":1,\"birthDay\":1,\"birthYear\":1900,\"id\":\"a1a1a1a...\"}
+   *
    * Any attestation that isn't a single string value will be
    * a JSON string representing the attestation data.
    */
+  // tslint:enable:max-line-length
   data: string
   /**
    * Attestation type nonce
@@ -68,7 +77,7 @@ export interface IAgreementParameters {
    */
   typeHash: string
   /**
-   * Attestation request nonce
+   * Meant to contain the value from generateAttestationRequestNonceHash
    */
   nonce: string
 }

--- a/src/HashingLogic.ts
+++ b/src/HashingLogic.ts
@@ -1,0 +1,96 @@
+import {AttestationTypeID} from './AttestationTypes'
+
+const {soliditySha3} = require('web3-utils')
+
+interface IAttestationData {
+  type: keyof typeof AttestationTypeID
+  provider?: string
+  data: string
+  nonce: string
+  version: string
+}
+
+export const hashAttestations = (attestations: IAttestationData[]) => {
+  const individualAttestationHashes = attestations.map(a =>
+    soliditySha3({
+      type: 'string',
+      value: JSON.stringify(a),
+    })
+  )
+  const combinedAttestationHash = soliditySha3({
+    type: 'string',
+    value: JSON.stringify(individualAttestationHashes),
+  })
+  return combinedAttestationHash
+}
+
+export const hashAttestationTypes = (types: AttestationTypeID[]) =>
+  soliditySha3({type: 'uint256[]', value: types})
+
+interface IAgreementParameters {
+  /**
+   * ETH address of the subject
+   */
+  subject: string
+  /**
+   * ETH address of the requester
+   */
+  requester: string
+  /**
+   * ETH address of the attester
+   */
+  attester: string
+  /**
+   * Meant to contain the value from hashAttestations
+   */
+  dataHash: string
+  /**
+   * Meant to contain the value from hashAttestationTypes
+   */
+  typeHash: string
+  /**
+   * Attestation request nonce
+   */
+  nonce: string
+}
+
+interface IAgreementEntry {
+  type: string
+  name: keyof IAgreementParameters
+  value: string
+}
+
+export const getAttestationAgreement = (
+  params: IAgreementParameters
+): IAgreementEntry[] => [
+  {
+    type: 'address',
+    name: 'subject',
+    value: params.subject,
+  },
+  {
+    type: 'address',
+    name: 'requester',
+    value: params.requester,
+  },
+  {
+    type: 'address',
+    name: 'attester',
+    value: params.attester,
+  },
+  {
+    type: 'bytes32',
+    name: 'dataHash',
+    value: params.dataHash,
+  },
+  {
+    type: 'bytes32',
+    name: 'typeHash',
+    value: params.typeHash,
+  },
+  {
+    type: 'bytes32',
+    name: 'nonce',
+    value: params.nonce,
+  },
+]

--- a/src/HashingLogic.ts
+++ b/src/HashingLogic.ts
@@ -136,3 +136,39 @@ export const getAttestationAgreement = (
     value: params.nonce,
   },
 ]
+
+export enum ChainId {
+  Main = 1,
+  Rinkeby = 4,
+}
+
+export const getAttestationAgreementEIP712 = (
+  params: IAgreementParameters,
+  chainId: ChainId,
+  verifyingContract: string
+) => ({
+  types: {
+    EIP712Domain: [
+      {name: 'name', type: 'string'},
+      {name: 'version', type: 'string'},
+      {name: 'chainId', type: 'uint256'},
+      {name: 'verifyingContract', type: 'address'},
+    ],
+    AttestationRequest: [
+      {name: 'subject', type: 'address'},
+      {name: 'attester', type: 'address'},
+      {name: 'requester', type: 'address'},
+      {name: 'dataHash', type: 'bytes32'},
+      {name: 'typeHash', type: 'bytes32'},
+      {name: 'nonce', type: 'bytes32'},
+    ],
+  },
+  primaryType: 'AttestationRequest',
+  domain: {
+    name: 'Bloom',
+    version: '1',
+    chainId,
+    verifyingContract,
+  },
+  message: params,
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target":
-      "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
-    "module":
-      "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
@@ -39,8 +37,7 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    "moduleResolution":
-      "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
@@ -60,6 +57,6 @@
     "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
     "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */
   },
-  "include": ["index.ts", "src/*"],
+  "include": ["index.ts", "src/*", "typings/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/typings/merkletreejs.d.ts
+++ b/typings/merkletreejs.d.ts
@@ -1,16 +1,23 @@
 declare module 'merkletreejs' {
+  interface IOptions {
+    isBitcoinTree: boolean
+  }
+
+  interface IProof {
+    position: 'left' | 'right'
+    data: Buffer
+  }
+
   export default class MerkleTree {
     getRoot: () => Buffer
     getLeaves: () => Buffer[]
     getLayers: () => Buffer[]
-    getProof: (leaf: Buffer, index?: number) => Buffer[]
-    verify: (proof: Buffer[], targetNode: Buffer, root: Buffer) => boolean
+    getProof: (leaf: Buffer, index?: number) => IProof[]
+    verify: (proof: IProof[], targetNode: Buffer, root: Buffer) => boolean
     constructor(
       leaves: Buffer[],
       hashAlgorithm: (data: any) => Buffer,
-      options?: {
-        isBitcoinTree: boolean
-      }
+      options?: IOptions
     )
   }
 }

--- a/typings/merkletreejs.d.ts
+++ b/typings/merkletreejs.d.ts
@@ -1,0 +1,16 @@
+declare module 'merkletreejs' {
+  export default class MerkleTree {
+    getRoot: () => Buffer
+    getLeaves: () => Buffer[]
+    getLayers: () => Buffer[]
+    getProof: (leaf: Buffer, index?: number) => Buffer[]
+    verify: (proof: Buffer[], targetNode: Buffer, root: Buffer) => boolean
+    constructor(
+      leaves: Buffer[],
+      hashAlgorithm: (data: any) => Buffer,
+      options?: {
+        isBitcoinTree: boolean
+      }
+    )
+  }
+}


### PR DESCRIPTION
Adds a HashingLogic export, which can be used to perform attestation hashes between bloom-web and attestation-kit. Also includes merkletree support. 