### PR TITLE
sort by leaf hash. standalone verify function

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Lint: Run `bin/tslint`
 Pretty: Run `bin/prettier`
 
 #### Packaging
+
 1. Bump version in `package.json` and commit / push
 2. Remove any previous package files from the repo directory (the next step would create the package with these unecessary files/folders)
 3. Run `yarn pack` to create the .tgz that will be uploaded in the following step.
-4. Create a release on GitHub, tag it with version number, associate it with the commit from step 1, and upload the aforementioned .tgz file. 
+4. Create a release on GitHub, tag it with version number, associate it with the commit from step 1, and upload the aforementioned .tgz file.
 
 #### Consuming
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attestations-lib",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "private": true,

--- a/src/HashingLogic.test.ts
+++ b/src/HashingLogic.test.ts
@@ -148,6 +148,11 @@ test('HashingLogic merkle trees / proofs', () => {
     nonce: 'a3877038-79a9-477d-8037-9826032e6af2',
     version: '1.0.0',
   }
+
+  const hashedEmailAttestation = HashingLogic.hashAttestation(emailAttestation)
+  const hashedPhoneAttestation = HashingLogic.hashAttestation(phoneAttestation)
+  const hashedFullNameAttestation = HashingLogic.hashAttestation(fullNameAttestation)
+
   const tree = HashingLogic.getMerkleTree([
     fullNameAttestation,
     emailAttestation,
@@ -156,20 +161,26 @@ test('HashingLogic merkle trees / proofs', () => {
   const root = tree.getRoot()
   const leaves = tree.getLeaves()
   const emailProof = tree.getProof(
-    Buffer.from(HashingLogic.hashAttestation(emailAttestation), 'hex')
+    Buffer.from(hashedEmailAttestation, 'hex')
   )
   const fullNameProof = tree.getProof(
-    Buffer.from(HashingLogic.hashAttestation(fullNameAttestation), 'hex')
+    Buffer.from(hashedFullNameAttestation, 'hex')
   )
   const phoneProof = tree.getProof(
-    Buffer.from(HashingLogic.hashAttestation(phoneAttestation), 'hex')
+    Buffer.from(hashedPhoneAttestation, 'hex')
   )
+
+  const treeDifferentOrder = HashingLogic.getMerkleTreeFromLeaves([
+    hashedEmailAttestation,
+    hashedFullNameAttestation,
+    hashedPhoneAttestation
+  ])
 
   const stringLeaves = leaves.map(x => x.toString('hex'))
   
-  const emailPosition = stringLeaves.indexOf(HashingLogic.hashAttestation(emailAttestation))
-  const fullNamePosition = stringLeaves.indexOf(HashingLogic.hashAttestation(fullNameAttestation))
-  const phonePosition = stringLeaves.indexOf(HashingLogic.hashAttestation(phoneAttestation))
+  const emailPosition = stringLeaves.indexOf(hashedEmailAttestation)
+  const fullNamePosition = stringLeaves.indexOf(hashedFullNameAttestation)
+  const phonePosition = stringLeaves.indexOf(hashedPhoneAttestation)
 
   expect(HashingLogic.verifyMerkleProof(emailProof, tree.getLeaves()[emailPosition], root)).toBeTruthy()
   expect(HashingLogic.verifyMerkleProof(emailProof, tree.getLeaves()[phonePosition], root)).toBeFalsy()
@@ -184,4 +195,6 @@ test('HashingLogic merkle trees / proofs', () => {
   expect(HashingLogic.verifyMerkleProof(phoneProof, leaves[phonePosition], root)).toBeTruthy()
 
   expect(HashingLogic.verifyMerkleProof([], Buffer.from(''), Buffer.from(''))).toBeFalsy()
+
+  expect (Buffer.compare(tree.getRoot(), treeDifferentOrder.getRoot()) === 0).toBeTruthy()
 })

--- a/src/HashingLogic.test.ts
+++ b/src/HashingLogic.test.ts
@@ -151,7 +151,9 @@ test('HashingLogic merkle trees / proofs', () => {
 
   const hashedEmailAttestation = HashingLogic.hashAttestation(emailAttestation)
   const hashedPhoneAttestation = HashingLogic.hashAttestation(phoneAttestation)
-  const hashedFullNameAttestation = HashingLogic.hashAttestation(fullNameAttestation)
+  const hashedFullNameAttestation = HashingLogic.hashAttestation(
+    fullNameAttestation
+  )
 
   const tree = HashingLogic.getMerkleTree([
     fullNameAttestation,
@@ -160,41 +162,75 @@ test('HashingLogic merkle trees / proofs', () => {
   ])
   const root = tree.getRoot()
   const leaves = tree.getLeaves()
-  const emailProof = tree.getProof(
-    Buffer.from(hashedEmailAttestation, 'hex')
-  )
+  const emailProof = tree.getProof(Buffer.from(hashedEmailAttestation, 'hex'))
   const fullNameProof = tree.getProof(
     Buffer.from(hashedFullNameAttestation, 'hex')
   )
-  const phoneProof = tree.getProof(
-    Buffer.from(hashedPhoneAttestation, 'hex')
-  )
+  const phoneProof = tree.getProof(Buffer.from(hashedPhoneAttestation, 'hex'))
 
   const treeDifferentOrder = HashingLogic.getMerkleTreeFromLeaves([
     hashedEmailAttestation,
     hashedFullNameAttestation,
-    hashedPhoneAttestation
+    hashedPhoneAttestation,
   ])
 
   const stringLeaves = leaves.map(x => x.toString('hex'))
-  
+
   const emailPosition = stringLeaves.indexOf(hashedEmailAttestation)
   const fullNamePosition = stringLeaves.indexOf(hashedFullNameAttestation)
   const phonePosition = stringLeaves.indexOf(hashedPhoneAttestation)
 
-  expect(HashingLogic.verifyMerkleProof(emailProof, tree.getLeaves()[emailPosition], root)).toBeTruthy()
-  expect(HashingLogic.verifyMerkleProof(emailProof, tree.getLeaves()[phonePosition], root)).toBeFalsy()
-  expect(HashingLogic.verifyMerkleProof(emailProof, tree.getLeaves()[fullNamePosition], root)).toBeFalsy()
+  expect(
+    HashingLogic.verifyMerkleProof(
+      emailProof,
+      tree.getLeaves()[emailPosition],
+      root
+    )
+  ).toBeTruthy()
+  expect(
+    HashingLogic.verifyMerkleProof(
+      emailProof,
+      tree.getLeaves()[phonePosition],
+      root
+    )
+  ).toBeFalsy()
+  expect(
+    HashingLogic.verifyMerkleProof(
+      emailProof,
+      tree.getLeaves()[fullNamePosition],
+      root
+    )
+  ).toBeFalsy()
 
-  expect(HashingLogic.verifyMerkleProof(fullNameProof, leaves[emailPosition], root)).toBeFalsy()
-  expect(HashingLogic.verifyMerkleProof(fullNameProof, leaves[fullNamePosition], root)).toBeTruthy()
-  expect(HashingLogic.verifyMerkleProof(fullNameProof, leaves[phonePosition], root)).toBeFalsy()
+  expect(
+    HashingLogic.verifyMerkleProof(fullNameProof, leaves[emailPosition], root)
+  ).toBeFalsy()
+  expect(
+    HashingLogic.verifyMerkleProof(
+      fullNameProof,
+      leaves[fullNamePosition],
+      root
+    )
+  ).toBeTruthy()
+  expect(
+    HashingLogic.verifyMerkleProof(fullNameProof, leaves[phonePosition], root)
+  ).toBeFalsy()
 
-  expect(HashingLogic.verifyMerkleProof(phoneProof, leaves[fullNamePosition], root)).toBeFalsy()
-  expect(HashingLogic.verifyMerkleProof(phoneProof, leaves[emailPosition], root)).toBeFalsy()
-  expect(HashingLogic.verifyMerkleProof(phoneProof, leaves[phonePosition], root)).toBeTruthy()
+  expect(
+    HashingLogic.verifyMerkleProof(phoneProof, leaves[fullNamePosition], root)
+  ).toBeFalsy()
+  expect(
+    HashingLogic.verifyMerkleProof(phoneProof, leaves[emailPosition], root)
+  ).toBeFalsy()
+  expect(
+    HashingLogic.verifyMerkleProof(phoneProof, leaves[phonePosition], root)
+  ).toBeTruthy()
 
-  expect(HashingLogic.verifyMerkleProof([], Buffer.from(''), Buffer.from(''))).toBeFalsy()
+  expect(
+    HashingLogic.verifyMerkleProof([], Buffer.from(''), Buffer.from(''))
+  ).toBeFalsy()
 
-  expect (Buffer.compare(tree.getRoot(), treeDifferentOrder.getRoot()) === 0).toBeTruthy()
+  expect(
+    Buffer.compare(tree.getRoot(), treeDifferentOrder.getRoot()) === 0
+  ).toBeTruthy()
 })

--- a/src/HashingLogic.test.ts
+++ b/src/HashingLogic.test.ts
@@ -165,15 +165,21 @@ test('HashingLogic merkle trees / proofs', () => {
     Buffer.from(HashingLogic.hashAttestation(phoneAttestation), 'hex')
   )
 
-  expect(tree.verify(emailProof, tree.getLeaves()[0], root)).toBeTruthy()
-  expect(tree.verify(emailProof, tree.getLeaves()[1], root)).toBeFalsy()
-  expect(tree.verify(emailProof, tree.getLeaves()[2], root)).toBeFalsy()
+  const stringLeaves = leaves.map(x => x.toString('hex'))
+  
+  const emailPosition = stringLeaves.indexOf(HashingLogic.hashAttestation(emailAttestation))
+  const fullNamePosition = stringLeaves.indexOf(HashingLogic.hashAttestation(fullNameAttestation))
+  const phonePosition = stringLeaves.indexOf(HashingLogic.hashAttestation(phoneAttestation))
 
-  expect(tree.verify(fullNameProof, leaves[0], root)).toBeFalsy()
-  expect(tree.verify(fullNameProof, leaves[1], root)).toBeTruthy()
-  expect(tree.verify(fullNameProof, leaves[2], root)).toBeFalsy()
+  expect(HashingLogic.verify(emailProof, tree.getLeaves()[emailPosition], root)).toBeTruthy()
+  expect(HashingLogic.verify(emailProof, tree.getLeaves()[phonePosition], root)).toBeFalsy()
+  expect(HashingLogic.verify(emailProof, tree.getLeaves()[fullNamePosition], root)).toBeFalsy()
 
-  expect(tree.verify(phoneProof, leaves[0], root)).toBeFalsy()
-  expect(tree.verify(phoneProof, leaves[1], root)).toBeFalsy()
-  expect(tree.verify(phoneProof, leaves[2], root)).toBeTruthy()
+  expect(HashingLogic.verify(fullNameProof, leaves[emailPosition], root)).toBeFalsy()
+  expect(HashingLogic.verify(fullNameProof, leaves[fullNamePosition], root)).toBeTruthy()
+  expect(HashingLogic.verify(fullNameProof, leaves[phonePosition], root)).toBeFalsy()
+
+  expect(HashingLogic.verify(phoneProof, leaves[fullNamePosition], root)).toBeFalsy()
+  expect(HashingLogic.verify(phoneProof, leaves[emailPosition], root)).toBeFalsy()
+  expect(HashingLogic.verify(phoneProof, leaves[phonePosition], root)).toBeTruthy()
 })

--- a/src/HashingLogic.test.ts
+++ b/src/HashingLogic.test.ts
@@ -171,15 +171,17 @@ test('HashingLogic merkle trees / proofs', () => {
   const fullNamePosition = stringLeaves.indexOf(HashingLogic.hashAttestation(fullNameAttestation))
   const phonePosition = stringLeaves.indexOf(HashingLogic.hashAttestation(phoneAttestation))
 
-  expect(HashingLogic.verify(emailProof, tree.getLeaves()[emailPosition], root)).toBeTruthy()
-  expect(HashingLogic.verify(emailProof, tree.getLeaves()[phonePosition], root)).toBeFalsy()
-  expect(HashingLogic.verify(emailProof, tree.getLeaves()[fullNamePosition], root)).toBeFalsy()
+  expect(HashingLogic.verifyMerkleProof(emailProof, tree.getLeaves()[emailPosition], root)).toBeTruthy()
+  expect(HashingLogic.verifyMerkleProof(emailProof, tree.getLeaves()[phonePosition], root)).toBeFalsy()
+  expect(HashingLogic.verifyMerkleProof(emailProof, tree.getLeaves()[fullNamePosition], root)).toBeFalsy()
 
-  expect(HashingLogic.verify(fullNameProof, leaves[emailPosition], root)).toBeFalsy()
-  expect(HashingLogic.verify(fullNameProof, leaves[fullNamePosition], root)).toBeTruthy()
-  expect(HashingLogic.verify(fullNameProof, leaves[phonePosition], root)).toBeFalsy()
+  expect(HashingLogic.verifyMerkleProof(fullNameProof, leaves[emailPosition], root)).toBeFalsy()
+  expect(HashingLogic.verifyMerkleProof(fullNameProof, leaves[fullNamePosition], root)).toBeTruthy()
+  expect(HashingLogic.verifyMerkleProof(fullNameProof, leaves[phonePosition], root)).toBeFalsy()
 
-  expect(HashingLogic.verify(phoneProof, leaves[fullNamePosition], root)).toBeFalsy()
-  expect(HashingLogic.verify(phoneProof, leaves[emailPosition], root)).toBeFalsy()
-  expect(HashingLogic.verify(phoneProof, leaves[phonePosition], root)).toBeTruthy()
+  expect(HashingLogic.verifyMerkleProof(phoneProof, leaves[fullNamePosition], root)).toBeFalsy()
+  expect(HashingLogic.verifyMerkleProof(phoneProof, leaves[emailPosition], root)).toBeFalsy()
+  expect(HashingLogic.verifyMerkleProof(phoneProof, leaves[phonePosition], root)).toBeTruthy()
+
+  expect(HashingLogic.verifyMerkleProof([], Buffer.from(''), Buffer.from(''))).toBeFalsy()
 })

--- a/src/HashingLogic.ts
+++ b/src/HashingLogic.ts
@@ -92,31 +92,29 @@ export const getMerkleTree = (attestations: IAttestationData[]) => {
  * 
  * standalone verify function taken from https://github.com/miguelmota/merkletreejs
  */
-export const verify = (
+export const verifyMerkleProof = (
   proof: IProof[],
   targetNode: Buffer,
   root: Buffer,
 ): boolean => {
-    let hash = targetNode
 
-    if (!Array.isArray(proof) ||
-        !proof.length ||
+    // Should not succeed with all empty arguments
+    if (!proof.length ||
         !targetNode ||
         !root) {
       return false
     }
 
-    for (let i = 0; i < proof.length; i++) {
-      const node = proof[i]
+    // Initialize hash with only targetNode data
+    let hash = targetNode
+
+    // Build hash using each component of proof until the root node
+    proof.forEach(node => {
       const isLeftNode = (node.position === 'left')
-      const buffers = []
-
-        buffers.push(hash)
-
-        buffers[isLeftNode ? 'unshift' : 'push'](node.data)
-
-        hash = Buffer.from(keccak256(Buffer.concat(buffers)), 'hex')
-    }
+      const buffers = [hash]
+      buffers[isLeftNode ? 'unshift' : 'push'](node.data)
+      hash = Buffer.from(keccak256(Buffer.concat(buffers)), 'hex')
+    })
 
     return Buffer.compare(hash, root) === 0
   }

--- a/src/HashingLogic.ts
+++ b/src/HashingLogic.ts
@@ -71,10 +71,7 @@ export const getMerkleTree = (attestations: IAttestationData[]) => {
   .map(hashAttestation)
   .sort()
   .map(hexStr => Buffer.from(hexStr, 'hex'))
-  // const leaves = sortBy(attestations, ['type'])
-  //   .map(hashAttestation)
-  //   .map(hexStr => Buffer.from(hexStr, 'hex'))
-  return new MerkleTree(leaves, x => Buffer.from(keccak256(x), 'hex'))
+  return new MerkleTree(leaves, (x: string) => Buffer.from(keccak256(x), 'hex'))
 }
 /**
  * verify

--- a/src/HashingLogic.ts
+++ b/src/HashingLogic.ts
@@ -71,7 +71,7 @@ export const getMerkleTree = (attestations: IAttestationData[]) => {
   .map(hashAttestation)
   .sort()
   .map(hexStr => Buffer.from(hexStr, 'hex'))
-  return new MerkleTree(leaves, (x: string) => Buffer.from(keccak256(x), 'hex'))
+  return new MerkleTree(leaves, (x: Buffer) => Buffer.from(keccak256(x), 'hex'))
 }
 /**
  * verify

--- a/src/HashingLogic.ts
+++ b/src/HashingLogic.ts
@@ -64,15 +64,22 @@ export const hashAttestation = (attestation: IAttestationData) => {
 
 /**
  * Given an array of IAttestationData, creates a new MerkleTree with the attestations
- * as the leaves being sorted by type and mapped into hash Buffers.
+ * after the leaves are sorted by hash and mapped into hash Buffers.
  */
 export const getMerkleTree = (attestations: IAttestationData[]) => {
-  const leaves = attestations
-  .map(hashAttestation)
-  .sort()
-  .map(hexStr => Buffer.from(hexStr, 'hex'))
-  return new MerkleTree(leaves, (x: Buffer) => Buffer.from(keccak256(x), 'hex'))
+  const leaves = attestations.map(hashAttestation)
+  return getMerkleTreeFromLeaves(leaves)
 }
+
+/**
+ * Given an array of hashed attestations, creates a new MerkleTree with the leaves
+ * after the leaves are sorted by hash and mapped into hash Buffers.
+ */
+export const getMerkleTreeFromLeaves = (leaves: string[]) => {
+  const leavesSorted = leaves.sort().map(hexStr => Buffer.from(hexStr, 'hex'))
+  return new MerkleTree(leavesSorted, (x: Buffer) => Buffer.from(keccak256(x), 'hex'))
+}
+
 /**
  * verify
  * @desc Returns true if the proof path (array of hashes) can connect the target node


### PR DESCRIPTION
extract verify function from method on tree class

fix hashAlgo in getMerkleTree

sort leaves by hash not by type

this should have been multiple commits probably