### PR TITLE
Give medical a non-zero `scoreWeight`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomprotocol/attestations-lib",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "Shared types and logic between blooms dApp and implementation of attestation-kit.",

--- a/src/AttestationTypes.ts
+++ b/src/AttestationTypes.ts
@@ -185,7 +185,7 @@ export const AttestationTypes: AttestationTypeManifest = {
   },
   medical: {
     id: AttestationTypeID['medical'],
-    scoreWeight: 0,
+    scoreWeight: 5,
     nameFriendly: 'Medical Information',
   },
   biometric: {


### PR DESCRIPTION
A zero `scoreWeight` will cause `getBloomIDStrength` to throw due to the conditional check in `getAttestationTypeAttrib` seeing 0 as a falsey value.