### PR TITLE
Blip4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloomprotocol/attestations-lib",
-  "version": "3.0.8",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "Shared types and logic between blooms dApp and implementation of attestation-kit.",

--- a/src/AttestationData.ts
+++ b/src/AttestationData.ts
@@ -122,12 +122,13 @@ export interface IBaseAttPhone extends IBaseAtt {
 // Email attestation dataStr type
 ///////////////////////////////////////////////////
 export interface IBaseAttEmailData extends IBaseAttDataObj {
-  email?: string
+  email: string
   start_date?: TDateOrTime
   end_date?: TDateOrTime
 }
+export type TBaseAttEmailData = string | IBaseAttEmailData
 export interface IBaseAttEmail extends IBaseAtt {
-  data: IBaseAttEmailData | Array<IBaseAttEmailData>
+  data: TBaseAttEmailData | Array<TBaseAttEmailData>
 }
 
 ///////////////////////////////////////////////////

--- a/src/HashingLogic.test.ts
+++ b/src/HashingLogic.test.ts
@@ -93,7 +93,7 @@ const emailRevocationLinks: HashingLogic.IRevocationLinks = {
 const emailAuxHash =
   '0x3a25e46865c7a4e0a5445b03b17d68c529826881647e6d58d3c4ad91ef83440f'
 
-const emailAttestation: HashingLogic.IAttestation = {
+const emailAttestation: HashingLogic.IAttestationLegacy = {
   data: emailAttestationData,
   type: emailAttestationType,
   aux: emailAuxHash,
@@ -129,7 +129,7 @@ const phoneRevocationLinks: HashingLogic.IRevocationLinks = {
 const phoneAuxHash =
   '0x303438fe19da4c3d85d6e746188618925c86d71b30b5443a0e4a7c56864e52b5'
 
-const phoneAttestation: HashingLogic.IAttestation = {
+const phoneAttestation: HashingLogic.IAttestationLegacy = {
   data: phoneAttestationData,
   type: phoneAttestationType,
   aux: phoneAuxHash,

--- a/src/HashingLogic.test.ts
+++ b/src/HashingLogic.test.ts
@@ -1,6 +1,7 @@
 import * as HashingLogic from './HashingLogic'
 import * as ethereumjsWallet from 'ethereumjs-wallet'
 const ethUtil = require('ethereumjs-util')
+const ethSigUtil = require('eth-sig-util')
 
 const aliceWallet = ethereumjsWallet.fromPrivateKey(
   new Buffer(
@@ -17,8 +18,13 @@ const bobWallet = ethereumjsWallet.fromPrivateKey(
   )
 )
 
+const bobPrivkey = bobWallet.getPrivateKey()
+const bobAddress = bobWallet.getAddressString()
+
 // tslint:disable:max-line-length
 const preComputedHashes = {
+  hashTest:
+    '0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658',
   emailAttestationType:
     '0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6',
   emailAttestationDataHash:
@@ -35,12 +41,16 @@ const preComputedHashes = {
     '0xeff7cf589aa83bb524c9daeb776d171558b77a17ada025a94a67b0086dac5ede',
   emailDataTreeHash:
     '0x0ef39bc9c680c01dbf61db1186ea4632bb195b85575eb205670cb146ee181275',
+  emailClaimTreeHash:
+    '0xf7c60d8617a2221b96f566d9251a2146315fbae08c385737d3575914dccb3d08',
   emailDataTreeHashAliceSigned:
     '0x124af1877444cbfea5a31a323449e76ab341c4df4d9943588fbe289c5eaf1bd339216d2e34c73d8d4f8f9f7bc939b1f127591ef25c4f1ce57d2e0af1a4cd8b561b',
   rootHash:
     '0xe72cf1f9a85fbc529cd17cded83d0021beb12359c7f238276d8e20aea603e928',
 }
 // tslint:enable:max-line-length
+
+const contractAddress = '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
 
 const preComputedAgreement = {
   types: {
@@ -60,7 +70,7 @@ const preComputedAgreement = {
     name: 'Bloom Attestation Logic',
     version: '2',
     chainId: 1,
-    verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+    verifyingContract: contractAddress,
   },
   message: {
     dataHash:
@@ -68,6 +78,9 @@ const preComputedAgreement = {
     nonce: '0xd5d7e6ae812a8ff7bd44f928b199806446c2170412df381efb41d8f47fcd044b',
   },
 }
+
+const validComponentVersions = ['Attestation-Tree-2.0.0']
+const validBatchComponentVersions = ['Batch-Attestation-Tree-1.0.0']
 
 const emailAttestationData: HashingLogic.IAttestationData = {
   data: 'test@bloom.co',
@@ -119,7 +132,7 @@ const emailAttestationNode: HashingLogic.IAttestationNode = {
   link: emailRevocationLinks,
 }
 
-const emailClaimNode: HashingLogic.IIssuedClaimNode = {
+const emailIssuedClaimNode: HashingLogic.IIssuedClaimNode = {
   data: emailAttestationData,
   type: emailAttestationType,
   aux: emailAuxHash,
@@ -191,6 +204,10 @@ const fourRootHashesDifferentOrder = [
   '0xf1e980ada99fc38d5e99d95d1ba52578ebd03caca349cfa1f1d721c954882550',
 ]
 
+test('HashingLogic.hashMessage', () => {
+  expect(HashingLogic.hashMessage('test')).toBe(preComputedHashes.hashTest)
+})
+
 test('HashingLogic.generateNonce', () => {
   const nonce = HashingLogic.generateNonce()
   expect(nonce.length).toBe(66)
@@ -261,69 +278,71 @@ test('HashingLogic.getMerkleTreeFromLeaves', () => {
 })
 
 test('HashingLogic.getClaimTree & hashClaimTree', () => {
-  const dataTreeA = HashingLogic.getClaimTree(emailAttestationNode)
-  const dataTreeHash = HashingLogic.hashAttestationNode(emailAttestationNode)
+  const claimTreeA = HashingLogic.getClaimTree(emailIssuedClaimNode)
+  const claimTreeHash = HashingLogic.hashClaimTree(emailIssuedClaimNode)
 
-  const dataTreeWrongDataNonce = HashingLogic.getDataTree({
+  const claimTreeWrongNonce = HashingLogic.getClaimTree({
     data: {
       data: 'test@bloom.co',
-      nonce: 'b3877038-79a9-477d-8037-9826032e6af0',
+      nonce: 'f4877038-79a9-477d-8037-9826032e6ag1',
       version: '1.0.0',
     },
     type: emailAttestationType,
-    link: emailRevocationLinks,
     aux: emailAuxHash,
+    issuance: emailIssuanceNode,
   })
 
-  const dataTreeWrongTypeNonce = HashingLogic.getDataTree({
+  const claimTreeWrongTypeNonce = HashingLogic.getClaimTree({
     data: emailAttestationData,
     type: {
       type: 'email',
       nonce: 'b3877038-79a9-477d-8037-9826032e6af1',
       provider: 'Bloom',
     },
-    link: emailRevocationLinks,
     aux: emailAuxHash,
+    issuance: emailIssuanceNode,
   })
 
-  const dataTreeWrongLink = HashingLogic.getDataTree({
+  const claimTreeWrongIssuance = HashingLogic.getClaimTree({
     data: emailAttestationData,
     type: emailAttestationType,
-    link: {
-      local:
-        '0x6a35e46865c7a4e0a5443b03d17d60c528896881646e6d58d3c4ad90ef84448e',
-      global:
+    issuance: {
+      localRevocationToken:
+        '0x5a35e46865c7a4e0a5443b03d17d60c528896881646e6d58d3c4ad90ef84448e',
+      globalRevocationToken:
         '0xe04448fe19da4c3d85d6e646188628825c86d71b30b5445a0e4a7c56864e53a7',
       dataHash:
         '0xd1696aa0222c2ee299efa58d265eaecc4677d8c88cb3a5c7e60bc5957fff514a',
       typeHash:
         '0x5aa3911df2dd532a0a03c7c6b6a234bb435a31dd9616477ef6cddacf014929df',
+      issuanceDate: '2017-02-01T00:00:00.000Z',
+      expirationDate: '2018-02-01T00:00:00.000Z',
     },
     aux: emailAuxHash,
   })
 
-  const dataTreeWrongAux = HashingLogic.getDataTree({
+  const claimTreeWrongAux = HashingLogic.getClaimTree({
     data: emailAttestationData,
     type: emailAttestationType,
-    link: emailRevocationLinks,
+    issuance: emailIssuanceNode,
     aux: '0xf04448fe19da4c3d85d6e646188628825c86d71b30b5445a0e4a7c56864e53a7',
   })
 
+  expect(claimTreeA.getRoot().equals(claimTreeWrongNonce.getRoot())).toBeFalsy()
   expect(
-    dataTreeA.getRoot().equals(dataTreeWrongDataNonce.getRoot())
+    claimTreeA.getRoot().equals(claimTreeWrongTypeNonce.getRoot())
   ).toBeFalsy()
   expect(
-    dataTreeA.getRoot().equals(dataTreeWrongTypeNonce.getRoot())
+    claimTreeA.getRoot().equals(claimTreeWrongIssuance.getRoot())
   ).toBeFalsy()
-  expect(dataTreeA.getRoot().equals(dataTreeWrongLink.getRoot())).toBeFalsy()
-  expect(dataTreeA.getRoot().equals(dataTreeWrongAux.getRoot())).toBeFalsy()
+  expect(claimTreeA.getRoot().equals(claimTreeWrongAux.getRoot())).toBeFalsy()
 
   // If this doesn't match something changed
-  expect(ethUtil.bufferToHex(dataTreeA.getRoot())).toBe(
-    preComputedHashes.emailDataTreeHash
+  expect(ethUtil.bufferToHex(claimTreeA.getRoot())).toBe(
+    preComputedHashes.emailClaimTreeHash
   )
 
-  expect(dataTreeA.getRoot().equals(dataTreeHash)).toBeTruthy()
+  expect(claimTreeA.getRoot().equals(claimTreeHash)).toBeTruthy()
 })
 
 test('HashingLogic.getDataTree & hashAttestationNode', () => {
@@ -743,6 +762,58 @@ test('Attestation Data Tree Proofs', () => {
   ).toBeFalsy()
 })
 
+test('HashingLogic.getSignedClaimNode', () => {
+  const globalLink = HashingLogic.generateNonce()
+  const issuedClaimNode = HashingLogic.getSignedClaimNode(
+    emailAttestation,
+    globalLink,
+    alicePrivkey,
+    emailIssuedClaimNode.issuance.issuanceDate,
+    emailIssuedClaimNode.issuance.expirationDate
+  )
+
+  expect(issuedClaimNode.claimNode.issuance.globalRevocationToken).toBe(
+    globalLink
+  )
+  expect(issuedClaimNode.claimNode.issuance.localRevocationToken.length).toBe(
+    66
+  )
+  expect(issuedClaimNode.claimNode.data).toEqual(emailAttestation.data)
+  expect(issuedClaimNode.claimNode.type).toEqual(emailAttestation.type)
+  expect(issuedClaimNode.claimNode.aux).toEqual(emailAttestation.aux)
+
+  const claimHash = HashingLogic.hashClaimTree(issuedClaimNode.claimNode)
+  const sender = HashingLogic.recoverHashSigner(
+    claimHash,
+    issuedClaimNode.attesterSig
+  )
+  expect(sender.toLowerCase()).toBe(
+    aliceWallet.getAddressString().toLowerCase()
+  )
+})
+
+test('HashingLogic.getSignedClaimNode date validation', () => {
+  const globalLink = HashingLogic.generateNonce()
+  expect(() => {
+    HashingLogic.getSignedClaimNode(
+      emailAttestation,
+      globalLink,
+      alicePrivkey,
+      'March 2, 2016',
+      emailIssuedClaimNode.issuance.expirationDate
+    )
+  }).toThrowError('Invalid issuance date')
+  expect(() => {
+    HashingLogic.getSignedClaimNode(
+      emailAttestation,
+      globalLink,
+      alicePrivkey,
+      emailIssuedClaimNode.issuance.issuanceDate,
+      'March 2, 2018'
+    )
+  }).toThrowError('Invalid expiration date')
+})
+
 test('HashingLogic.getSignedDataNodes', () => {
   const globalLink = HashingLogic.generateNonce()
   const dataNode = HashingLogic.getSignedDataNode(
@@ -769,7 +840,7 @@ test('HashingLogic.getSignedDataNodes', () => {
   )
 })
 
-test('HashingLogic.getSignedMerkleTreeComponents', () => {
+test('HashingLogic.getSignedMerkleTreeComponentsLegacy', () => {
   const components = HashingLogic.getSignedMerkleTreeComponentsLegacy(
     [emailAttestation, phoneAttestation],
     alicePrivkey
@@ -823,10 +894,193 @@ test('HashingLogic.getSignedMerkleTreeComponents', () => {
   expect(rootHashFromComponents.equals(rootHash)).toBeTruthy()
 })
 
+test('HashingLogic.getSignedMerkleTreeComponents', () => {
+  const components = HashingLogic.getSignedMerkleTreeComponents(
+    [emailAttestation, phoneAttestation],
+    emailIssuedClaimNode.issuance.issuanceDate,
+    emailIssuedClaimNode.issuance.expirationDate,
+    alicePrivkey
+  )
+
+  expect(validComponentVersions.indexOf(components.version)).toBeGreaterThan(-1)
+
+  expect(components.paddingNodes.length).toBe(13)
+  components.paddingNodes.forEach(p => {
+    expect(p.length).toBe(66)
+  })
+
+  const checksum = HashingLogic.getChecksum(
+    components.claimNodes.map(a => HashingLogic.hashMessage(a.attesterSig))
+  )
+  const checksumSigner = HashingLogic.recoverHashSigner(
+    checksum,
+    components.checksumSig
+  )
+  expect(checksumSigner.toLowerCase()).toBe(
+    aliceWallet.getAddressString().toLowerCase()
+  )
+
+  const rootHash = HashingLogic.getBloomMerkleTree(
+    components.claimNodes.map(a => HashingLogic.hashMessage(a.attesterSig)),
+    components.paddingNodes,
+    HashingLogic.hashMessage(components.checksumSig)
+  ).getRoot()
+
+  expect(ethUtil.bufferToHex(rootHash)).toBe(components.rootHash)
+
+  const rootHashSigner = HashingLogic.recoverHashSigner(
+    rootHash,
+    components.signedRootHash
+  )
+  expect(rootHashSigner.toLowerCase()).toBe(
+    aliceWallet.getAddressString().toLowerCase()
+  )
+
+  const layer2Hash = HashingLogic.hashMessage(
+    HashingLogic.orderedStringify({
+      rootHash: ethUtil.bufferToHex(rootHash),
+      nonce: components.rootHashNonce,
+    })
+  )
+  expect(layer2Hash).toBe(components.layer2Hash)
+
+  const rootHashFromComponents = HashingLogic.getMerkleTreeFromComponents(
+    components
+  ).getRoot()
+  expect(rootHashFromComponents.equals(rootHash)).toBeTruthy()
+})
+
+test('HashingLogic.getSignedBatchMerkleTreeComponents', () => {
+  const components = HashingLogic.getSignedMerkleTreeComponents(
+    [emailAttestation, phoneAttestation],
+    emailIssuedClaimNode.issuance.issuanceDate,
+    emailIssuedClaimNode.issuance.expirationDate,
+    alicePrivkey
+  )
+
+  const bobSubjectSig = ethSigUtil.signTypedData(bobPrivkey, {
+    data: HashingLogic.getAttestationAgreement(
+      contractAddress,
+      1,
+      components.rootHash,
+      components.rootHashNonce
+    ),
+  })
+
+  const batchComponents = HashingLogic.getSignedBatchMerkleTreeComponents(
+    components,
+    contractAddress,
+    bobSubjectSig,
+    bobAddress,
+    alicePrivkey
+  )
+
+  expect(
+    validBatchComponentVersions.indexOf(batchComponents.version)
+  ).toBeGreaterThan(-1)
+
+  // batch should have same length as non-batch
+  expect(batchComponents.paddingNodes.length).toBe(
+    components.paddingNodes.length
+  )
+
+  batchComponents.paddingNodes.forEach(p => {
+    expect(p.length).toBe(66)
+  })
+
+  // checksum should be the same as non-batch
+  const checksum = HashingLogic.getChecksum(
+    batchComponents.claimNodes.map(a => HashingLogic.hashMessage(a.attesterSig))
+  )
+
+  expect(ethUtil.bufferToHex(checksum)).toBe(
+    ethUtil.bufferToHex(
+      HashingLogic.getChecksum(
+        components.claimNodes.map(a => HashingLogic.hashMessage(a.attesterSig))
+      )
+    )
+  )
+
+  expect(batchComponents.checksumSig).toBe(components.checksumSig)
+
+  expect(batchComponents.rootHash).toBe(components.rootHash)
+  expect(batchComponents.rootHashNonce).toBe(components.rootHashNonce)
+
+  const layer2Hash = HashingLogic.hashMessage(
+    HashingLogic.orderedStringify({
+      subjectSig: batchComponents.subjectSig,
+      attesterSig: batchComponents.attesterSig,
+    })
+  )
+  expect(layer2Hash).toBe(batchComponents.batchLayer2Hash)
+  expect(batchComponents.batchLayer2Hash).not.toBe(components.layer2Hash)
+
+  const rootHashFromComponents = HashingLogic.getMerkleTreeFromComponents(
+    batchComponents
+  ).getRoot()
+  expect(
+    rootHashFromComponents.equals(
+      HashingLogic.getMerkleTreeFromComponents(components).getRoot()
+    )
+  ).toBeTruthy()
+
+  const recoveredAttester = HashingLogic.recoverHashSigner(
+    ethUtil.toBuffer(
+      HashingLogic.hashMessage(
+        HashingLogic.orderedStringify({
+          subject: bobAddress,
+          rootHash: batchComponents.rootHash,
+        })
+      )
+    ),
+    batchComponents.attesterSig
+  )
+  expect(recoveredAttester.toLowerCase()).toBe(
+    aliceWallet.getAddressString().toLowerCase()
+  )
+  const recoveredSubject = ethSigUtil.recoverTypedSignature({
+    data: HashingLogic.getAttestationAgreement(
+      batchComponents.contractAddress,
+      1,
+      batchComponents.rootHash,
+      batchComponents.rootHashNonce
+    ),
+    sig: batchComponents.subjectSig,
+  })
+  expect(recoveredSubject.toLowerCase()).toBe(batchComponents.subject)
+})
+
+test('HashingLogic.getSignedBatchMerkleTreeComponents sig validation', () => {
+  const components = HashingLogic.getSignedMerkleTreeComponents(
+    [emailAttestation, phoneAttestation],
+    emailIssuedClaimNode.issuance.issuanceDate,
+    emailIssuedClaimNode.issuance.expirationDate,
+    alicePrivkey
+  )
+
+  const bobInvalidSubjectSig = ethSigUtil.signTypedData(bobPrivkey, {
+    data: HashingLogic.getAttestationAgreement(
+      contractAddress,
+      1,
+      '0xe6d7e6ae812a8ff7bd44f928b199806446c2170412df381efb41d8f47fcd045c',
+      components.rootHashNonce
+    ),
+  })
+
+  expect(() => {
+    HashingLogic.getSignedBatchMerkleTreeComponents(
+      components,
+      contractAddress,
+      bobInvalidSubjectSig,
+      bobAddress,
+      alicePrivkey
+    )
+  }).toThrowError(new Error('Invalid subject sig'))
+})
+
 test(
   'HashingLogic getAttestationAgreement' + ' - has not been modified',
   () => {
-    const contractAddress = '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
     const dataHash = preComputedHashes.rootHash
     const nonce =
       '0xd5d7e6ae812a8ff7bd44f928b199806446c2170412df381efb41d8f47fcd044b'

--- a/src/HashingLogic.ts
+++ b/src/HashingLogic.ts
@@ -2,11 +2,11 @@ import {AttestationTypeID} from './AttestationTypes'
 import {keccak256} from 'js-sha3'
 const crypto = require('crypto')
 import MerkleTree, {IProof} from 'merkletreejs'
-import { validateDateTime } from './RFC3339DateTime';
+import {validateDateTime} from './RFC3339DateTime'
 const ethUtil = require('ethereumjs-util')
 const ethSigUtil = require('eth-sig-util')
 
-export const hashMessage = (message: string) =>
+export const hashMessage = (message: string): string =>
   ethUtil.addHexPrefix(keccak256(message))
 
 /**
@@ -249,7 +249,9 @@ export const getSignedClaimNode = (
 ): ISignedClaimNode => {
   // validateDates
   if (!validateDateTime(issuanceDate)) throw new Error('Invalid issuance date')
-  if (!validateDateTime(expirationDate)) throw new Error('Invalid expiration date')
+  if (!validateDateTime(expirationDate)) {
+    throw new Error('Invalid expiration date')
+  }
   const issuedClaimNode: IIssuedClaimNode = {
     data: claimNode.data,
     type: claimNode.type,
@@ -516,11 +518,13 @@ export const getSignedBatchMerkleTreeComponents = (
     throw new Error('Invalid subject sig')
   }
   const attesterSig = signHash(
-    hashMessage(
-      orderedStringify({
-        subject: subject,
-        rootHash: components.rootHash,
-      })
+    ethUtil.toBuffer(
+      hashMessage(
+        orderedStringify({
+          subject: subject,
+          rootHash: components.rootHash,
+        })
+      )
     ),
     privKey
   )
@@ -604,7 +608,7 @@ export const getMerkleTreeFromComponentsLegacy = (
 }
 
 export const getMerkleTreeFromComponents = (
-  components: IBloomMerkleTreeComponents
+  components: IBloomMerkleTreeComponents | IBloomBatchMerkleTreeComponents
 ): MerkleTree => {
   const signedDataHashes = components.claimNodes.map(a =>
     hashMessage(a.attesterSig)

--- a/src/RFC3339DateTime.ts
+++ b/src/RFC3339DateTime.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2017, Dirk-Jan Rutten
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree:
+ * https://github.com/excitement-engineer/graphql-iso-date
+ *
+ */
+
+// Check whether a certain year is a leap year.
+//
+// Every year that is exactly divisible by four
+// is a leap year, except for years that are exactly
+// divisible by 100, but these centurial years are
+// leap years if they are exactly divisible by 400.
+// For example, the years 1700, 1800, and 1900 are not leap years,
+// but the years 1600 and 2000 are.
+//
+const leapYear = (year: number): boolean => {
+  return ((year % 4 === 0) && (year % 100 !== 0)) || (year % 400 === 0)
+}
+
+// Function that checks whether a time-string is RFC 3339 compliant.
+//
+// It checks whether the time-string is structured in one of the
+// following formats:
+//
+// - hh:mm:ssZ
+// - hh:mm:ss±hh:mm
+// - hh:mm:ss.*sZ
+// - hh:mm:ss.*s±hh:mm
+//
+// Where *s is a fraction of seconds with at least 1 digit.
+//
+// Note, this validator assumes that all minutes have
+// 59 seconds. This assumption does not follow RFC 3339
+// which includes leap seconds (in which case it is possible that
+// there are 60 seconds in a minute).
+//
+// Leap seconds are ignored because it adds complexity in
+// the following areas:
+// - The native Javascript Date ignores them; i.e. Date.parse('1972-12-31T23:59:60Z')
+//   equals NaN.
+// - Leap seconds cannot be known in advance.
+//
+export const validateTime = (time: string): boolean => {
+  // tslint:disable-next-line:max-line-length
+  const TIME_REGEX = /^([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(\.\d{1,})?(([Z])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))$/
+  return TIME_REGEX.test(time)
+}
+
+// Function that checks whether a date-string is RFC 3339 compliant.
+//
+// It checks whether the date-string is a valid date in the YYYY-MM-DD.
+//
+// Note, the number of days in each date are determined according to the
+// following lookup table:
+//
+// Month Number  Month/Year           Maximum value of date-mday
+// ------------  ----------           --------------------------
+// 01            January              31
+// 02            February, normal     28
+// 02            February, leap year  29
+// 03            March                31
+// 04            April                30
+// 05            May                  31
+// 06            June                 30
+// 07            July                 31
+// 08            August               31
+// 09            September            30
+// 10            October              31
+// 11            November             30
+// 12            December             31
+//
+export const validateDate = (datestring: string): boolean => {
+  const RFC_3339_REGEX = /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))$/
+
+  if (!RFC_3339_REGEX.test(datestring)) {
+    return false
+  }
+
+  // Verify the correct number of days for
+  // the month contained in the date-string.
+  const year = Number(datestring.substr(0, 4))
+  const month = Number(datestring.substr(5, 2))
+  const day = Number(datestring.substr(8, 2))
+
+  switch (month) {
+    case 2: // February
+      if (leapYear(year) && day > 29) {
+        return false
+      } else if (!leapYear(year) && day > 28) {
+        return false
+      }
+      return true
+    case 4: // April
+    case 6: // June
+    case 9: // September
+    case 11: // November
+      if (day > 30) {
+        return false
+      }
+      break
+    default:
+      break
+  }
+
+  return true
+}
+
+// Function that checks whether a date-time-string is RFC 3339 compliant.
+//
+// It checks whether the time-string is structured in one of the
+//
+// - YYYY-MM-DDThh:mm:ssZ
+// - YYYY-MM-DDThh:mm:ss±hh:mm
+// - YYYY-MM-DDThh:mm:ss.*sZ
+// - YYYY-MM-DDThh:mm:ss.*s±hh:mm
+//
+// Where *s is a fraction of seconds with at least 1 digit.
+//
+export const validateDateTime = (dateTimeString: string): boolean => {
+  // tslint:disable-next-line:max-line-length
+  const RFC_3339_REGEX = /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60))(\.\d{1,})?(([Z])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))$/
+
+  // Validate the structure of the date-string
+  if (!RFC_3339_REGEX.test(dateTimeString)) {
+    return false
+  }
+
+  // Check if it is a correct date using the javascript Date parse() method.
+  const time = Date.parse(dateTimeString)
+  if (time !== time) { // eslint-disable-line
+    return false
+  }
+  // Split the date-time-string up into the string-date and time-string part.
+  // and check whether these parts are RFC 3339 compliant.
+  const index = dateTimeString.indexOf('T')
+  const dateString = dateTimeString.substr(0, index)
+  const timeString = dateTimeString.substr(index + 1)
+  return (validateDate(dateString) && validateTime(timeString))
+}


### PR DESCRIPTION
Breaking change

Change old Merkle tree format to 'legacy' methods

2 new Merkle tree methods. getSignedMerkleTreeComponents and getSignedBatchMerkleTreeComponents

1. Subject provides data to attester
2. Attester calls `getSignedMerkleTreeComponents` and passes root hash back to subject to sign
3. If using the new batch tree structure, attester calls `getSignedBatchMerkleTreeComponents` to incorporate subjectSig into layer2hash

compare with spec here:
https://github.com/hellobloom/specs/blob/fc631eab2c1e1a30ad77b664080114cc6ad3cab3/attestation-data/Bloom-Merkle-Tree-22facf0b-bedb-4b45-bb7d-edcd57213eb0.md